### PR TITLE
force odd number of samples for filter

### DIFF
--- a/blink.py
+++ b/blink.py
@@ -297,7 +297,7 @@ class BlinkDetector(object):
         # detection parameters in samples
         distance_between_blinks = 1
         width_of_blink = width_of_blink * ms_to_sample
-        filter_length = filter_length * ms_to_sample
+        filter_length = preprocessing.nearest_odd_integer(filter_length * ms_to_sample)
 
         # Interpolate gaps
         eye_openness_signal = preprocessing.interpolate_nans(t, eye_openness_signal,

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -62,3 +62,21 @@ def interpolate_nans(t, y, gap_dur=np.inf):
     y[y == -1000] = np.nan
 
     return y
+
+
+#%%
+def nearest_odd_integer(x):
+    """Returns nearest odd integer of input value.
+
+    Input:
+        - x, float or integer
+    Output:
+        - integer value that is odd
+    Example:
+        >>> nearest_odd_integer(6.25)
+            7
+        >>> nearest_odd_integer(5.99)
+            5
+    """
+
+    return int(2*np.floor(x/2)+1)


### PR DESCRIPTION
Forcing odd number of samples for SG filter in the EO blink detector in order to prevent a slight phase-shift in the filtered signal.